### PR TITLE
Update dockerfile to set entrypoint and use official golang image

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -1,10 +1,8 @@
-# Ubuntu LTS by default
-FROM ubuntu:18.04
-RUN apt-get update && apt-get install -y \
-  golang-go \
-  make
-COPY . /joueur
-RUN cd /joueur && make
+FROM golang:1.15.5-buster
+WORKDIR /client
+COPY . .
+RUN make
+ENTRYPOINT ["joueur"]
 
 # Your client image should now be ready to run on an arena.
 # If you use require additional dependencies add them here as a RUN command.


### PR DESCRIPTION
The other dockerfiles have an ENTRYPOINT directive so that the binary name doesn't need to be known by the arena, so I've added that directive, also I've changed the base image from ubuntu to golang official debian-based one.