### PR TITLE
Fix --index flag

### DIFF
--- a/internal/run.go
+++ b/internal/run.go
@@ -75,7 +75,7 @@ func Run(args RunArgs) error {
 	playerIndex := -1
 	if args.Index != "" {
 		i, err := strconv.Atoi(args.Index)
-		if err == nil {
+		if err != nil {
 			errorhandler.HandleError(
 				errorhandler.InvalidArgs,
 				err,


### PR DESCRIPTION
The error checking logic was reversed and would fail on valid values like "--index=1"